### PR TITLE
feat(docs): theme-dark samples

### DIFF
--- a/assets/style/site.css
+++ b/assets/style/site.css
@@ -1,0 +1,62 @@
+body {
+  background-color: #f8f8f8;
+}
+
+.demo__code {
+  overflow: auto;
+  max-width: 100%;
+}
+
+.area {
+  display: flex;
+}
+
+.presentation-tile {
+  flex-grow: 0;
+}
+
+.demo[id*=sample][id*=theme-dark] {
+  background-color: #454545;
+  padding: 1rem;
+}
+
+[href*='assets.ruxitlabs.com']:before,
+[href*='lab.dynatrace']:before {
+  background-image: url(/assets/icons/Icons_file_003_Dont_Watch_eye.svg);
+  content: '';
+  width: 16px;
+  height: 13px;
+  display: inline-block;
+  background-size: 100%;
+}
+
+.component {
+  display: inline-block;
+  width: 150px;
+  height: 150px;
+  background-color: #00a1b2;
+  color: white;
+  text-align: center;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  position: relative;
+}
+
+.component__image {
+  max-width: 110px;
+  margin: 0 auto;
+  padding: 10px;
+  display: block;
+}
+
+.component__headline {
+  position: absolute;
+  width: 100%;
+  left: 0;
+  bottom: 10px;
+}
+
+.component:hover .component__headline,
+.component__headline:hover {
+  color: #fafafa;
+}

--- a/docs/_templates/layouts/default.hbs
+++ b/docs/_templates/layouts/default.hbs
@@ -8,66 +8,7 @@
     <link rel="stylesheet" href="{{sitedata.site.baseurl}}/css/main.css" charset="utf-8">
     <link rel="stylesheet" href="{{sitedata.site.baseurl}}/css/base/fonts.css" charset="utf-8">
     <link rel="stylesheet" href="{{sitedata.site.baseurl}}/assets/style/syntax.css" charset="utf-8">
-    <style media="screen">
-      body {
-        background-color: #f8f8f8;
-      }
-
-      .demo__code {
-        overflow: auto;
-        max-width: 100%;
-      }
-
-      .area {
-        display: flex;
-      }
-
-      .presentation-tile {
-        flex-grow: 0;
-      }
-
-      [href*='assets.ruxitlabs.com']:before,
-      [href*='lab.dynatrace']:before {
-        background-image: url(/assets/icons/Icons_file_003_Dont_Watch_eye.svg);
-        content: '';
-        width: 16px;
-        height: 13px;
-        display: inline-block;
-        background-size: 100%;
-      }
-
-      .component {
-        display: inline-block;
-        width: 150px;
-        height: 150px;
-        background-color: #00a1b2;
-        color: white;
-        text-align: center;
-        margin-right: 10px;
-        margin-bottom: 10px;
-        position: relative;
-      }
-
-      .component__image {
-        max-width: 110px;
-        margin: 0 auto;
-        padding: 10px;
-        display: block;
-      }
-
-      .component__headline {
-        position: absolute;
-        width: 100%;
-        left: 0;
-        bottom: 10px;
-      }
-
-      .component:hover .component__headline,
-      .component__headline:hover {
-        color: #fafafa;
-      }
-
-    </style>
+    <link rel="stylesheet" href="{{sitedata.site.baseurl}}/assets/style/site.css" charset="utf-8">
   </head>
   <body {{#if theme}}class="{{theme}}"{{/if}}>
     {{> navigation}}

--- a/docs/_templates/partials/component_content.hbs
+++ b/docs/_templates/partials/component_content.hbs
@@ -3,10 +3,10 @@
 {{#if samples}}
 <h2>Examples</h2>
 {{#each samples}}
-  <div class="demo">
+  <div class="demo" id="sample-{{this.name}}">
   {{{this.code}}}
   </div>
-  <div class="demo__code">
+  <div class="demo__code" id="code-{{this.name}}">
     <pre><code>
 {{{highlight this.code 'html'}}}</code>
     </pre>


### PR DESCRIPTION
Includes

- site.css is now an own file instead of being directly in the guide
- samples now get IDs:
  - the sample itself has "sample-{{filename}}"
  - the code has "code-{{filename}}"
- all samples with "theme-dark" in its name are getting a dark background.