### PR TITLE
Use the correct class to set sidebar item active

### DIFF
--- a/docs/_pages/layouts/sidebar-and-content.html
+++ b/docs/_pages/layouts/sidebar-and-content.html
@@ -6,7 +6,7 @@ type: layout
 ---
 <div class="layout is-flex">
   <nav class="sidebar hide-sm">
-    <a href="#" class="sidebar__item sidebar__item--active">
+    <a href="#" class="sidebar__item is-active">
       <span class="sidebar__headline">General</span>
       <span class="sidebar__info">See your Application setup</span>
     </a>


### PR DESCRIPTION
I think a wrong (old?) active class is used in the sidebar & content example.