### PR TITLE
fix(slider): typo in background

### DIFF
--- a/src/slider/slider.scss
+++ b/src/slider/slider.scss
@@ -9,7 +9,7 @@
   cursor: pointer;
   width: 100%;
   max-width: 320px;
-  background: tranparent;
+  background: transparent;
   background-image: linear-gradient(to right, $turquoise-600 0%, $turquoise-600 50%, $disabledcolor 50%, $disabledcolor 100%);
   background-size: 100% 2px;
   background-position: left center;


### PR DESCRIPTION
I wonder why the linter would let this pass? 