### PR TITLE
fix(table) nowrap white-space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/groundhog",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "CSS components for Dynatrace",
   "main": "dist/js/main.js",
   "scripts": {

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -88,6 +88,7 @@ $breakpoint: 920px !default;
     overflow: hidden;
     padding-top: 0;
     padding-bottom: 0;
+    white-space: nowrap;
   }
 
 


### PR DESCRIPTION
Not allowing text to wrap creates good headlines, plus it fixes issues with the line.