### PR TITLE
docs(changelog): manually updated changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ assets/icons
 groundhog-assets.zip
 .DS_Store
 aws.json
-docs/_pages/changelog.md

--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -15,6 +15,7 @@ hideCode: true
 * **sidebar:** ellipsis for items longer than the area ([fe5de6d](https://github.com/Dynatrace/css-groundhog/commit/fe5de6d))
 
 ### Features
+* **navbar:** keyboard support for searchfield ([59c40b8](https://github.com/Dynatrace/css-groundhog/commit/59c40b8))
 
 #### Updated components
 

--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -1,10 +1,10 @@
 ---
 title: Changelog
-layout: islands.hbs
- hideCode: true
+layout: single-island.hbs
+hideCode: true
 ---
-# Changelog
 
+# Changelog
 
 
 <a name="2.0.0"></a>
@@ -33,7 +33,6 @@ layout: islands.hbs
 <a name="1.0.0"></a>
 # [1.0.0](https://github.com/Dynatrace/css-groundhog/compare/v0.10.1...v1.0.0) (2017-07-14)
 
-* version++
 
 <a name="0.10.1"></a>
 ## [0.10.1](https://github.com/Dynatrace/css-groundhog/compare/v0.10.0...v0.10.1) (2017-07-11)

--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -1,0 +1,323 @@
+---
+title: Changelog
+layout: islands.hbs
+ hideCode: true
+---
+# Changelog
+
+
+
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/Dynatrace/css-groundhog/compare/v1.0.0...v2.0.0) (2017-07-31)
+
+### Bug Fixes
+
+* **sidebar:** ellipsis for items longer than the area ([fe5de6d](https://github.com/Dynatrace/css-groundhog/commit/fe5de6d))
+
+### Features
+
+#### Updated components
+
+* **navbar:** new secondary nav styles for desktop and mobile ([52a9372](https://github.com/Dynatrace/css-groundhog/commit/52a9372))
+* **navbar:** new two bars layout, new position for buttongroup items, new examples ([8c17408](https://github.com/Dynatrace/css-groundhog/commit/8c17408))
+* **expandable:** add modifier for navigation components ([72319af](https://github.com/Dynatrace/css-groundhog/commit/72319af))
+* **expandable:** updated active class and added separated version ([7773239](https://github.com/Dynatrace/css-groundhog/commit/7773239))
+
+#### New components
+
+* **layouts:** multi column layouts ([9fe43cc](https://github.com/Dynatrace/css-groundhog/commit/9fe43cc))
+* **subnav:** new subnav component ([9e87b5b](https://github.com/Dynatrace/css-groundhog/commit/9e87b5b))
+* **progressbar:** basic progressbar styling ([097c792](https://github.com/Dynatrace/css-groundhog/commit/097c792))
+
+
+<a name="1.0.0"></a>
+# [1.0.0](https://github.com/Dynatrace/css-groundhog/compare/v0.10.1...v1.0.0) (2017-07-14)
+
+* version++
+
+<a name="0.10.1"></a>
+## [0.10.1](https://github.com/Dynatrace/css-groundhog/compare/v0.10.0...v0.10.1) (2017-07-11)
+
+
+### Bug Fixes
+
+* **list:** lessen specificity for nested ul ([ff7e170](https://github.com/Dynatrace/css-groundhog/commit/ff7e170))
+* **list:** put back the default color ([eec5746](https://github.com/Dynatrace/css-groundhog/commit/eec5746))
+* **list:** themes apply to lists ([a50b568](https://github.com/Dynatrace/css-groundhog/commit/a50b568))
+
+
+
+<a name="0.10.0"></a>
+# [0.10.0](https://github.com/Dynatrace/css-groundhog/compare/v0.9.0...v0.10.0) (2017-07-11)
+
+### Bug Fixes
+
+* **navbar:** added height for logo position in ie11(Win8.1) ([7143abc](https://github.com/Dynatrace/css-groundhog/commit/7143abc))
+* **navbar:** polyfill for search on ie11 ([e47c7e0](https://github.com/Dynatrace/css-groundhog/commit/e47c7e0))
+* **tile, select:** looks the same on ie11 now ([a32b8a1](https://github.com/Dynatrace/css-groundhog/commit/a32b8a1))
+
+<a name="0.9.0"></a>
+# [0.9.0](https://github.com/Dynatrace/css-groundhog/compare/v0.8.0...v0.9.0) (2017-06-29)
+
+
+### Bug Fixes
+
+* **navbar:** added url attr for results in navbar search ([9a229e7](https://github.com/Dynatrace/css-groundhog/commit/9a229e7))
+
+
+<a name="0.8.0"></a>
+# [0.8.0](https://github.com/Dynatrace/css-groundhog/compare/v0.7.0...v0.8.0) (2017-06-19)
+
+### Bug Fixes
+
+* **expandable-table:** fix border color on active ([e26fd2e](https://github.com/Dynatrace/css-groundhog/commit/e26fd2e))
+* **navbar:** make fetching the navbar search results more generic ([b4f14e5](https://github.com/Dynatrace/css-groundhog/commit/b4f14e5))
+* **navbar:** Missing radix parameter ([85e62ee](https://github.com/Dynatrace/css-groundhog/commit/85e62ee))
+* **pre:** set code block max-width. Should not overflow anymore. ([7c6ea90](https://github.com/Dynatrace/css-groundhog/commit/7c6ea90))
+
+
+### Features
+
+#### Updated components
+
+* **list:** nested ul and ol styling ([af01b97](https://github.com/Dynatrace/css-groundhog/commit/af01b97))
+
+#### New components
+
+* **dl:** dl basic version. + Updated list icon for component preview ([cab3beb](https://github.com/Dynatrace/css-groundhog/commit/cab3beb))
+* **steps:** steps styling ([c58ae5a](https://github.com/Dynatrace/css-groundhog/commit/c58ae5a))
+* **steps:** steps styling + examples. Unordered list component is now available in 'list'. Updated test page with new lists. ([c3e2188](https://github.com/Dynatrace/css-groundhog/commit/c3e2188))
+
+<a name="0.7.0"></a>
+# [0.7.0](https://github.com/Dynatrace/css-groundhog/compare/v0.6.6...v0.7.0) (2017-06-12)
+
+
+### Bug Fixes
+
+* checkbox position ([b6dd7f2](https://github.com/Dynatrace/css-groundhog/commit/b6dd7f2))
+
+
+<a name="0.6.6"></a>
+## [0.6.6](https://github.com/Dynatrace/css-groundhog/compare/v0.6.5...v0.6.6) (2017-05-24)
+
+
+### Bug Fixes
+
+* **hint:** removed padding left and max-width. ([5d2efc9](https://github.com/Dynatrace/css-groundhog/commit/5d2efc9))
+* **navbar:** fixed navbar height ([510ddc1](https://github.com/Dynatrace/css-groundhog/commit/510ddc1))
+* **navbar:** we dont need the default here ([43c4a28](https://github.com/Dynatrace/css-groundhog/commit/43c4a28))
+
+
+
+<a name="0.6.5"></a>
+## [0.6.5](https://github.com/Dynatrace/css-groundhog/compare/v0.6.4...v0.6.5) (2017-05-15)
+
+
+### Bug Fixes
+
+* **caption:** removed width of caption -> should be done by container ([bc4e04c](https://github.com/Dynatrace/css-groundhog/commit/bc4e04c))
+* **doc:** expand thumbnail for pagination ([e4d29a9](https://github.com/Dynatrace/css-groundhog/commit/e4d29a9))
+* **textarea:** margin bottom shouldn't be part of textarea ([d6a79d6](https://github.com/Dynatrace/css-groundhog/commit/d6a79d6))
+* **tile:** updated margin for tile lists ([c1a191b](https://github.com/Dynatrace/css-groundhog/commit/c1a191b))
+* **typography:** updated fonts, line-heights, margins... ([89e9ba5](https://github.com/Dynatrace/css-groundhog/commit/89e9ba5))
+
+
+### Features
+
+* **component test page:** added test pages overview and version++ ([ce9083e](https://github.com/Dynatrace/css-groundhog/commit/ce9083e))
+* **test page:** added test page for our components ([3068155](https://github.com/Dynatrace/css-groundhog/commit/3068155))
+
+
+<a name="0.6.4"></a>
+## [0.6.4](https://github.com/Dynatrace/css-groundhog/compare/v0.6.3...v0.6.4) (2017-04-24)
+
+
+### Bug Fixes
+
+* **button:** reset theme--dark link style for button ([2929cd2](https://github.com/Dynatrace/css-groundhog/commit/2929cd2))
+* **expandable:** increase css specificity to prevent expandable from being overridden ([841b065](https://github.com/Dynatrace/css-groundhog/commit/841b065))
+
+
+
+<a name="0.6.3"></a>
+## [0.6.3](https://github.com/Dynatrace/css-groundhog/compare/v0.6.2...v0.6.3) (2017-04-24)
+
+
+### Bug Fixes
+
+* **toggler:** add check if target element is not undefined ([2350cee](https://github.com/Dynatrace/css-groundhog/commit/2350cee))
+
+
+
+<a name="0.6.2"></a>
+## [0.6.2](https://github.com/Dynatrace/css-groundhog/compare/v0.6.1...v0.6.2) (2017-04-19)
+
+
+### Bug Fixes
+
+* **search:** added action attr to form elements and updated js accordingly ([34aff95](https://github.com/Dynatrace/css-groundhog/commit/34aff95))
+
+
+### Features
+
+* **figcaption:** caption examples and styling ([eabcc32](https://github.com/Dynatrace/css-groundhog/commit/eabcc32))
+
+
+<a name="0.6.1"></a>
+## [0.6.1](https://github.com/Dynatrace/css-groundhog/compare/v0.6.0...v0.6.1) (2017-04-12)
+
+### Features
+
+* **navbar:** search field for nav ([0e97b65](https://github.com/Dynatrace/css-groundhog/commit/0e97b65))
+
+
+<a name="0.6.0"></a>
+# [0.6.0](https://github.com/Dynatrace/css-groundhog/compare/v0.5.0...v0.6.0) (2017-04-05)
+
+
+### Features
+
+* **table:** updated table css and added readme ([01af8e6](https://github.com/Dynatrace/css-groundhog/commit/01af8e6))
+* **loading:** updated loading__box to loading ([408dfa0](https://github.com/Dynatrace/css-groundhog/commit/408dfa0))
+
+
+<a name="0.5.0"></a>
+# [0.5.0](https://github.com/Dynatrace/css-groundhog/compare/v0.4.0...v0.5.0) (2017-04-04)
+
+
+### Bug Fixes
+
+* **slider:** typo in background ([b958bd2](https://github.com/Dynatrace/css-groundhog/commit/b958bd2))
+
+
+### Features
+
+* **link:** added style for link on theme-dark ([a54d751](https://github.com/Dynatrace/css-groundhog/commit/a54d751))
+* **link:** added theme-dark class to link component ([9784216](https://github.com/Dynatrace/css-groundhog/commit/9784216))
+
+
+<a name="0.4.0"></a>
+# [0.4.0](https://github.com/Dynatrace/css-groundhog/compare/v0.3.2...v0.4.0) (2017-03-20)
+
+
+### Features
+
+* **footer:** extend btn styles for social links ([2deff85](https://github.com/Dynatrace/css-groundhog/commit/2deff85))
+* **navbar:** added search input to examples ([8d2a33d](https://github.com/Dynatrace/css-groundhog/commit/8d2a33d))
+
+
+<a name="0.3.2"></a>
+## [0.3.2](https://github.com/Dynatrace/css-groundhog/compare/v0.2.1...v0.3.2) (2017-02-08)
+
+
+### Bug Fixes
+
+* **loading:** updated animation so it works in edge and safari ([957e28a](https://github.com/Dynatrace/css-groundhog/commit/957e28a))
+
+
+### Features
+
+* **loading:** icon for nav ([0b945b8](https://github.com/Dynatrace/css-groundhog/commit/0b945b8))
+* **loading spinner:** loading spinner examples and basic styling ([1d4434e](https://github.com/Dynatrace/css-groundhog/commit/1d4434e))
+
+
+
+<a name="0.2.1"></a>
+## [0.2.1](https://github.com/Dynatrace/css-groundhog/compare/v0.1.1...v0.2.1) (2017-02-01)
+
+
+### Bug Fixes
+
+* **table:** fixed issue when td is used within thead instead of th ([51fc76a](https://github.com/Dynatrace/css-groundhog/commit/51fc76a))
+* **table:** text overflow and column width ([d190cc7](https://github.com/Dynatrace/css-groundhog/commit/d190cc7))
+
+
+### Features
+
+* **table:** basic styling for responsive tables ([e46bf8a](https://github.com/Dynatrace/css-groundhog/commit/e46bf8a))
+* **table:** js for responsive table ([d7a9c0a](https://github.com/Dynatrace/css-groundhog/commit/d7a9c0a))
+* **table:** js for responsive table headers ([b0d8908](https://github.com/Dynatrace/css-groundhog/commit/b0d8908))
+
+
+
+<a name="0.1.1"></a>
+## [0.1.1](https://github.com/Dynatrace/css-groundhog/compare/e51abf7...v0.1.1) (2017-01-24)
+
+
+### Bug Fixes
+
+* **button:** adjusted active states too ([6953dd8](https://github.com/Dynatrace/css-groundhog/commit/6953dd8))
+* **button:** text color to #fff ([4322a05](https://github.com/Dynatrace/css-groundhog/commit/4322a05))
+* **button:** updated font color for active state ([9550d12](https://github.com/Dynatrace/css-groundhog/commit/9550d12))
+* **button:** updated hover border color ([8066811](https://github.com/Dynatrace/css-groundhog/commit/8066811))
+* **button:** updated hover styles of secondary buttons ([6524c86](https://github.com/Dynatrace/css-groundhog/commit/6524c86))
+* **button:** updated to new color scheme ([476aaa6](https://github.com/Dynatrace/css-groundhog/commit/476aaa6))
+* **checkbox:** 2 pixel dass de so auffoin kinnan ne ([ae8f2c1](https://github.com/Dynatrace/css-groundhog/commit/ae8f2c1))
+* **checkbox:** color names are new ([f272ef3](https://github.com/Dynatrace/css-groundhog/commit/f272ef3))
+* **checkbox:** fixed styling bug of checkbox and radiobutton ([50c4f53](https://github.com/Dynatrace/css-groundhog/commit/50c4f53))
+* **checkbox:** is in a different branch ([b8ace8a](https://github.com/Dynatrace/css-groundhog/commit/b8ace8a))
+* **checkbox:** satisfy linter ([61c0fa1](https://github.com/Dynatrace/css-groundhog/commit/61c0fa1))
+* **colors:** putting a dash in and adding the typography ([e51abf7](https://github.com/Dynatrace/css-groundhog/commit/e51abf7))
+* **colors:** removing steelgray ([16d0839](https://github.com/Dynatrace/css-groundhog/commit/16d0839))
+* **dropdown:** arrow can be done in css, no js needed ([29bbb94](https://github.com/Dynatrace/css-groundhog/commit/29bbb94))
+* **expandable:** expandable-trigger now uses closest-function to get parent element ([552bc69](https://github.com/Dynatrace/css-groundhog/commit/552bc69))
+* **expandable:** fixed positioning of expandable-trigger icon ([e711840](https://github.com/Dynatrace/css-groundhog/commit/e711840))
+* **expandable:** fixed positioning of trigger-icon in IE ([84c4cee](https://github.com/Dynatrace/css-groundhog/commit/84c4cee))
+* **expandable table:** HTML and CSS improvements ([b6a1881](https://github.com/Dynatrace/css-groundhog/commit/b6a1881))
+* **hint for inputfield and textarea:** fixed hint styles and added icon for input field ([143cc47](https://github.com/Dynatrace/css-groundhog/commit/143cc47))
+* **inputfield:** deleted js, animation is done by css ([891ae1b](https://github.com/Dynatrace/css-groundhog/commit/891ae1b))
+* **inputfield:** updated placeholder text ([136ffea](https://github.com/Dynatrace/css-groundhog/commit/136ffea))
+* **inputfield:** watermark color ([a7bed3b](https://github.com/Dynatrace/css-groundhog/commit/a7bed3b))
+* **inputfield and textarea:** fix hint position ([d631517](https://github.com/Dynatrace/css-groundhog/commit/d631517))
+* **link:** updated link-color to turquoise ([4c62a5b](https://github.com/Dynatrace/css-groundhog/commit/4c62a5b))
+* **media component:** code improvements ([aa83304](https://github.com/Dynatrace/css-groundhog/commit/aa83304))
+* **nav:** new navigation ([5aa9bf8](https://github.com/Dynatrace/css-groundhog/commit/5aa9bf8))
+* **navbar:** changed logo URL ([baea541](https://github.com/Dynatrace/css-groundhog/commit/baea541))
+* **navbar:** visited is important ([0469aa3](https://github.com/Dynatrace/css-groundhog/commit/0469aa3))
+* **nested ordered list:** fixed styling of nested ol in ul.list ([da830fe](https://github.com/Dynatrace/css-groundhog/commit/da830fe))
+* **pre:** pre fix like in the help ([184112c](https://github.com/Dynatrace/css-groundhog/commit/184112c))
+* **select:** rotate arrow when dropdown open ([adcc70e](https://github.com/Dynatrace/css-groundhog/commit/adcc70e))
+* **select:** updated js and html to have options directly in the html and not loaded from a json ([6d08a1c](https://github.com/Dynatrace/css-groundhog/commit/6d08a1c))
+* **slider:** appearance on edge and ie ([d488574](https://github.com/Dynatrace/css-groundhog/commit/d488574))
+* **slider:** set min max if they are null ([992174b](https://github.com/Dynatrace/css-groundhog/commit/992174b))
+* **slider:** updated main.js and main.scss to fix conflicts with master branch ([4dc7263](https://github.com/Dynatrace/css-groundhog/commit/4dc7263))
+* **slider:** updated O/0 sign ([f760168](https://github.com/Dynatrace/css-groundhog/commit/f760168))
+* **switch:** 0 instead of circle ([5b946eb](https://github.com/Dynatrace/css-groundhog/commit/5b946eb))
+* **switch:** updated tumb size of switch ([5225842](https://github.com/Dynatrace/css-groundhog/commit/5225842))
+* **table:** added margin-bottom to table ([63f364f](https://github.com/Dynatrace/css-groundhog/commit/63f364f))
+* **tag:** ghosty test class is not needed anymore ([b2158d2](https://github.com/Dynatrace/css-groundhog/commit/b2158d2))
+* **tag:** increased margin bottom to style multiple lines of tags ([cb6431c](https://github.com/Dynatrace/css-groundhog/commit/cb6431c))
+* **text-color:** adding a color katrin likes ([5e19d90](https://github.com/Dynatrace/css-groundhog/commit/5e19d90))
+* **unordered list:** code improvements ([de93643](https://github.com/Dynatrace/css-groundhog/commit/de93643))
+
+
+### Features
+
+* **accordion:** data-behavior=accordion can now be used, used for expandable table ([86424e9](https://github.com/Dynatrace/css-groundhog/commit/86424e9))
+* **checkbox:** added dark theme for checkbox ([3d8314f](https://github.com/Dynatrace/css-groundhog/commit/3d8314f))
+* **closest polyfill:** added closest and matches polyfill ([a60f5f9](https://github.com/Dynatrace/css-groundhog/commit/a60f5f9))
+* **expandable:** initialized state and function ([999525f](https://github.com/Dynatrace/css-groundhog/commit/999525f))
+* **expandable table:** expandable table now imports styles from table and expandable ([fb0896c](https://github.com/Dynatrace/css-groundhog/commit/fb0896c))
+* **expandable table:** initial commit for expandable table component ([83d4fb5](https://github.com/Dynatrace/css-groundhog/commit/83d4fb5))
+* **fieldset:** added layout for forms and fieldsets ([07dc7d7](https://github.com/Dynatrace/css-groundhog/commit/07dc7d7))
+* **fieldset:** updated spacing in forms ([7b9d9eb](https://github.com/Dynatrace/css-groundhog/commit/7b9d9eb))
+* **forms:** added field styling and restructured typo check.md ([d278725](https://github.com/Dynatrace/css-groundhog/commit/d278725))
+* **forms:** updated html/fieldset structure in typo check ([77a6335](https://github.com/Dynatrace/css-groundhog/commit/77a6335))
+* **inputfield:** hover :) ([e6f4081](https://github.com/Dynatrace/css-groundhog/commit/e6f4081))
+* **layouts:** its getting complete ([7c0350c](https://github.com/Dynatrace/css-groundhog/commit/7c0350c))
+* **media component:** improved/extended media component ([264b3cc](https://github.com/Dynatrace/css-groundhog/commit/264b3cc))
+* **media component:** initial commit ([9234fca](https://github.com/Dynatrace/css-groundhog/commit/9234fca))
+* **navbar:** new examples ([aee7f95](https://github.com/Dynatrace/css-groundhog/commit/aee7f95))
+* **navbar:** examples have different ids to work in doc ([c0387c8](https://github.com/Dynatrace/css-groundhog/commit/c0387c8))
+* **select:** added dropdown icons ([3cc535e](https://github.com/Dynatrace/css-groundhog/commit/3cc535e))
+* **select:** added nav icon ([290119b](https://github.com/Dynatrace/css-groundhog/commit/290119b))
+* **slider:** started with basic styles ([6cdd5fc](https://github.com/Dynatrace/css-groundhog/commit/6cdd5fc))
+* **slider:** started with js for changing slider colors ([61e4699](https://github.com/Dynatrace/css-groundhog/commit/61e4699))
+* **tabs:** add themes and pointer-event properties ([a7500dd](https://github.com/Dynatrace/css-groundhog/commit/a7500dd))
+* **tabs:** script to enable tab toggling ([d6451a9](https://github.com/Dynatrace/css-groundhog/commit/d6451a9))
+* **tabs:** update samples for theme use ([de8d0ce](https://github.com/Dynatrace/css-groundhog/commit/de8d0ce))
+* **tag:** clickable tags ([ea86499](https://github.com/Dynatrace/css-groundhog/commit/ea86499))
+* **textarea:** added basic styles for textarea component ([7913cc1](https://github.com/Dynatrace/css-groundhog/commit/7913cc1))
+* **textarea:** added navicon for textarea ([b2eb831](https://github.com/Dynatrace/css-groundhog/commit/b2eb831))
+* **unordered list:** icon ([654ad7b](https://github.com/Dynatrace/css-groundhog/commit/654ad7b))
+* **unordered list:** initial commit for unordered list component ([00ddd5d](https://github.com/Dynatrace/css-groundhog/commit/00ddd5d))

--- a/docs/_templates/layouts/single-island.hbs
+++ b/docs/_templates/layouts/single-island.hbs
@@ -1,0 +1,11 @@
+{{#extend 'islands'}}
+
+{{#content 'area'}}
+<div class="layout is-flex has-islands">
+  <div class="island">
+    {{{contents}}}
+  </div>
+</div>
+{{/content}}
+
+{{/extend}}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -270,65 +270,14 @@ gulp.task('dev', (done) => {
   gulp.watch([scriptFiles], ['scripts:lint', 'scripts']);
   gulp.watch(['src/**/samples/**/*.html', 'src/**/README.md', 'docs/**/*'], ['doc']);
   runSequence('copy-assets', 'icons', 'styles:lint', 'styles',
-    'scripts:lint', 'scripts', 'changelog', 'doc', 'serve', done);
+    'scripts:lint', 'scripts', 'doc', 'serve', done);
 });
 
 gulp.task('build', (done) => {
   runSequence('copy-assets', 'icons',
-    ['styles:lint', 'scripts:lint'], ['styles', 'scripts'], 'changelog', 'doc', done);
+    ['styles:lint', 'scripts:lint'], ['styles', 'scripts'], 'doc', done);
 });
 
 gulp.task('publish', (done) => {
   runSequence('replace-asset-urls', 'replace-asset-urls-in-html', 'package', 'upload-s3', done);
-});
-
-const addChangelogPage = () => {
-  return through(
-    {
-      objectMode: true,
-      allowHalfOpen: false,
-    },
-    function (file, enc, cb) {
-      cb(null, file); // noop
-    },
-    function (cb) {
-      const f = new Vinyl({
-        cwd: '.',
-        base: './docs/_pages/',
-        contents: new Buffer(''),
-        path: './docs/_pages/changelog.md',
-      })
-      this.push(f);
-      cb(); // flush;
-    }
-  );
-};
-
-const prependfrontmatter = () => {
-  return through(
-    {
-      objectMode: true,
-      allowHalfOpen: false,
-    },
-    function (file, enc, cb) {
-      const content = file.contents;
-      const frontmatter = '---\ntitle: Changelog\nlayout: islands.hbs\n hideCode: true\n---\n# Changelog\n\n';
-      file.contents = new Buffer(`${frontmatter}\n\n${content}`);
-      cb(null, file); // noop
-    },
-    function (cb) {
-      cb(); // flush;
-    }
-  );
-};
-
-gulp.task('changelog', () => {
-  return gulp.src('docs/_pages/changelog1.md', { read: false })
-    .pipe(addChangelogPage())
-    .pipe(changelog({
-      preset: 'angular',
-      releaseCount: 0,
-    }))
-    .pipe(prependfrontmatter())
-  .pipe(gulp.dest('docs/_pages/'));
 });


### PR DESCRIPTION
There were some issues with commit messages shown on the wrong place and for the wrong version  updates (depending on the version number in the local package.json at the time of the commit)... I think, I fixed most of them.

For future changelog updates I would suggest to separate entries about "new components" and "modified/updated components" in the features section. I don't know if we should always link the specific commits, but we could keep the links to the version diffs in the headlines.