### PR TITLE
Fix badcrumb

### DIFF
--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -6,6 +6,12 @@ hideCode: true
 
 # Changelog
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/Dynatrace/css-groundhog/compare/v2.1.1...v2.1.2) (2017-08-10)
+
+### Bug Fixes
+
+* **breadcrumbs:** Fixed distance if element is only last
 
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/Dynatrace/css-groundhog/compare/v2.1.0...v2.1.1) (2017-08-10)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/groundhog",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CSS components for Dynatrace",
   "main": "dist/js/main.js",
   "scripts": {

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -25,7 +25,8 @@ $breadcrumb-active-color: $turquoise-700;
   position: relative;
 }
 
-.breadcrumbs__item:first-child .breadcrumbs__link {
+.breadcrumbs__item:first-child .breadcrumbs__link,
+.breadcrumbs__item:first-child .breadcrumbs__last {
   padding-left: 1.7rem;
 }
 


### PR DESCRIPTION
Issue presists if there is only a `breadcrumb__last` in the breadcrumbs

![screen shot 2017-08-10 at 15 32 12](https://user-images.githubusercontent.com/6338434/29172713-1acb07d4-7de1-11e7-80d8-06b0b01fc48d.png)
