### PR TITLE
fix(base): removed em from html font size def

### DIFF
--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -6,12 +6,17 @@ hideCode: true
 
 # Changelog
 
-<a name="2.1.3"></a>
-## [2.1.3](https://github.com/Dynatrace/css-groundhog/compare/v2.1.2...v2.1.3) (2017-08-17)
+<a name="2.1.4"></a>
+## [2.1.4](https://github.com/Dynatrace/css-groundhog/compare/v2.1.3...v2.1.4) (2017-08-28)
 
 ### Bug Fixes
 
 * **base:** Fixed root font size
+
+<a name="2.1.3"></a>
+## [2.1.3](https://github.com/Dynatrace/css-groundhog/compare/v2.1.2...v2.1.3) (2017-08-18)
+
+* **doc:** added version to header in the doc
 
 <a name="2.1.2"></a>
 ## [2.1.2](https://github.com/Dynatrace/css-groundhog/compare/v2.1.1...v2.1.2) (2017-08-10)

--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -6,6 +6,13 @@ hideCode: true
 
 # Changelog
 
+<a name="2.1.3"></a>
+## [2.1.3](https://github.com/Dynatrace/css-groundhog/compare/v2.1.2...v2.1.3) (2017-08-17)
+
+### Bug Fixes
+
+* **base:** Fixed root font size
+
 <a name="2.1.2"></a>
 ## [2.1.2](https://github.com/Dynatrace/css-groundhog/compare/v2.1.1...v2.1.2) (2017-08-10)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/groundhog",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "CSS components for Dynatrace",
   "main": "dist/js/main.js",
   "scripts": {

--- a/src/base/typography.scss
+++ b/src/base/typography.scss
@@ -44,7 +44,7 @@ $typecsset-base-line-height: 24px !default;
  */
 
 html {
-  font-size: $typecsset-base-font-size / 16px + em; /* [1] */
+  font-size: $typecsset-base-font-size; /* [1] */
   line-height: $typecsset-base-line-height / $typecsset-base-font-size; /* [2] */
 }
 


### PR DESCRIPTION
removed em from html font size def, because 1rem in code blocks was rendered in different sizes depending on the parent. 