### PR TITLE
fix internet explorer issue that caused invalid flex value

### DIFF
--- a/docs/_pages/changelog.md
+++ b/docs/_pages/changelog.md
@@ -6,6 +6,13 @@ hideCode: true
 
 # Changelog
 
+<a name="6.1.2"></a>
+## [6.1.2](https://github.com/Dynatrace/css-groundhog/compare/v6.1.1...v6.1.2) (2018-11-15)
+
+### Bug fixes
+
+* **column:** Fixed IE Bug with flexbox calc. Thanks to [internetztube](https://github.com/internetztube) for the fix.
+
 <a name="6.1.1"></a>
 ## [6.1.1](https://github.com/Dynatrace/css-groundhog/compare/v6.1.0...v6.1.1) (2018-04-11)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynatrace/groundhog",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "CSS components for Dynatrace",
   "main": "dist/js/main.js",
   "scripts": {

--- a/src/common/_mixins.scss
+++ b/src/common/_mixins.scss
@@ -32,7 +32,9 @@ $columngap: 24px;
 
     .column--#{$i}-of-#{$noOfColumns} {
       max-width: calc(#{100% / $noOfColumns * $i} - #{$columngap});
-      flex: 1 0 calc(#{100% / $noOfColumns * $i} - #{$columngap});
+      flex-grow: 1;
+      flex-shrink: 0;
+      flex-basis: calc(#{100% / $noOfColumns * $i} - #{$columngap});
     }
   }
 }


### PR DESCRIPTION
Internet Explorer 11 does not support flex shorthand with calc as flex-basis
See https://github.com/philipwalton/flexbugs#flexbug-8